### PR TITLE
Manage the web server port using ENV

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
   :profiles {
     :dev {
       :dependencies [
+        [environ        "1.1.0"]
         [ring/ring-mock "0.3.2"]
       ]
       :plugins [

--- a/src/pablito/server.clj
+++ b/src/pablito/server.clj
@@ -2,6 +2,7 @@
   (:require
    [compojure.route]
    [compojure.core :as compojure]
+   [environ.core :refer [env]]
    [hiccup.core :as hiccup]
    [immutant.web :as web])
   (:gen-class))
@@ -16,7 +17,7 @@
   (compojure.route/not-found "Not found"))
 
 (defn run []
-  (let [port-str "3000"]
+  (let [port-str (env :port "3000")]
     (println "Starting web server on port" port-str)
     (web/run #'application {:port (Integer/parseInt port-str)})))
 


### PR DESCRIPTION
 - Add `[environ "1.1.0"]` as ENV manager
 - Use `PORT` ENV as a value for the server port